### PR TITLE
Hackage policy compliance

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -21,9 +21,9 @@ description:         Please see the README on GitHub at <https://github.com/skri
 
 dependencies:
 - base >= 4.7 && < 5
-- inline-c
-- text
-- bytestring
+- inline-c >= 0.9.1 && < 0.10
+- text >= 1.2.4 && < 1.3
+- bytestring >= 0.10.12 && < 0.11
 
 library:
   source-dirs: src

--- a/zyre2.cabal
+++ b/zyre2.cabal
@@ -44,9 +44,9 @@ library
       czmq
   build-depends:
       base >=4.7 && <5
-    , bytestring
-    , inline-c
-    , text
+    , bytestring >=0.10.12 && <0.11
+    , inline-c >=0.9.1 && <0.10
+    , text >=1.2.4 && <1.3
   default-language: Haskell2010
 
 executable zyre-example-exe
@@ -58,9 +58,9 @@ executable zyre-example-exe
   ghc-options: -threaded -rtsopts -with-rtsopts=-N
   build-depends:
       base >=4.7 && <5
-    , bytestring
-    , inline-c
-    , text
+    , bytestring >=0.10.12 && <0.11
+    , inline-c >=0.9.1 && <0.10
+    , text >=1.2.4 && <1.3
     , zyre2
   default-language: Haskell2010
 
@@ -74,8 +74,8 @@ test-suite zyre2-test
   ghc-options: -threaded -rtsopts -with-rtsopts=-N
   build-depends:
       base >=4.7 && <5
-    , bytestring
-    , inline-c
-    , text
+    , bytestring >=0.10.12 && <0.11
+    , inline-c >=0.9.1 && <0.10
+    , text >=1.2.4 && <1.3
     , zyre2
   default-language: Haskell2010


### PR DESCRIPTION
Bring the package into compliance with hackage policy.

- [X] Version bounds for dependencies.
- [X] PVP versioning compliance: No action needed at the moment.
- [X] Update release v0.1.0.3 with policy compliance version bounds